### PR TITLE
Pin PKCS#1 v1.5 padding and SHA-1 for RSA-SHA1 signatures

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,24 @@
 Revision history for Net-OAuth
 
+       [Bug Fixes]
+       - RSA-SHA1 now pins PKCS#1 v1.5 padding and the SHA-1 hash rather
+         than inheriting Crypt::OpenSSL::RSA's defaults, which have drifted
+         (SHA-256 in 0.29_01, RSA-PSS in 0.35). Against 0.35 and later this
+         produced RSA-PSS signatures that no RFC 5849 3.4.3 compliant server
+         will accept. Reported as Debian #1142954.
+
+       [Tests]
+       - t/02-rsa.t asserts the signature base string separately from the
+         signature, so a failure distinguishes base-string construction from
+         the crypto layer.
+
+       - t/02-rsa.t skips with a diagnostic on Crypt::OpenSSL::RSA 0.35
+         through 0.37, which disabled the PKCS#1 v1.5 padding that OAuth
+         RSA-SHA1 requires; 0.38 re-enabled it.
+
+       [Toolchain]
+       - Recommend Crypt::OpenSSL::RSA 0.38 or later for RSA-SHA1.
+
        [Documentation]
        - Added missing version and timestamp to Changes for v0.31.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,9 +27,24 @@ WriteMakefile(
     'EXE_FILES'   => [],
     'PL_FILES'    => {},
     'META_MERGE'  => {
+        'meta-spec' => { version => 2 },
+        prereqs     => {
+            # Only needed for the RSA-SHA1 signature method, so not a hard
+            # prereq. 0.38 is a floor rather than a preference: 0.35 through
+            # 0.37 disabled the PKCS#1 v1.5 padding that RFC 5849 3.4.3
+            # mandates, and 0.38 re-enabled it.
+            runtime => { recommends => { 'Crypt::OpenSSL::RSA' => '0.38' } },
+            test    => { recommends => { 'Crypt::OpenSSL::RSA' => '0.38' } },
+        },
         resources => {
-            bugtracker => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Net-OAuth',
-            repository => 'https://github.com/keeth/Net-OAuth.git',
+            bugtracker => {
+                web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Net-OAuth',
+            },
+            repository => {
+                url  => 'https://github.com/keeth/Net-OAuth.git',
+                web  => 'https://github.com/keeth/Net-OAuth',
+                type => 'git',
+            },
         },
     },
 );

--- a/lib/Net/OAuth/SignatureMethod/RSA_SHA1.pm
+++ b/lib/Net/OAuth/SignatureMethod/RSA_SHA1.pm
@@ -3,12 +3,27 @@ use warnings;
 use strict;
 use MIME::Base64;
 
+# RFC 5849 3.4.3 mandates RSASSA-PKCS1-v1_5 with SHA-1. Crypt::OpenSSL::RSA
+# defaults have drifted (SHA-256 since 0.29_01, PSS padding since 0.35), so
+# pin both rather than inheriting whatever the installed version prefers.
+sub _apply_rfc5849_defaults {
+    my $key = shift;
+    for my $method (qw(use_sha1_hash use_pkcs1_padding)) {
+        next unless UNIVERSAL::can($key, $method);
+        eval { $key->$method; 1 }
+            or die "Your Crypt::OpenSSL::RSA cannot do $method, which OAuth "
+                 . "RSA-SHA1 requires (RFC 5849 3.4.3): $@";
+    }
+    return $key;
+}
+
 sub sign {
     my $self = shift;
     my $request = shift;
 	my $key = shift || $request->signature_key;
     die '$request->signature_key must be an RSA key object (e.g. Crypt::OpenSSL::RSA) that can sign($text)'
         unless UNIVERSAL::can($key, 'sign');
+    _apply_rfc5849_defaults($key);
     return encode_base64($key->sign($request->signature_base_string), "");
 }
 
@@ -18,6 +33,7 @@ sub verify {
     my $key = shift || $request->signature_key;
     die 'You must pass an RSA key object (e.g. Crypt::OpenSSL::RSA) that can verify($text,$sig)'
         unless UNIVERSAL::can($key, 'verify');
+    _apply_rfc5849_defaults($key);
     return $key->verify($request->signature_base_string, decode_base64($request->signature));
 }
 

--- a/t/02-rsa.t
+++ b/t/02-rsa.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use Net::OAuth::ProtectedResourceRequest;
 
@@ -14,7 +14,7 @@ sub slurp {
 
 SKIP: {
 
-    skip "Crypt::OpenSSL::RSA not installed", 2 unless eval 'require Crypt::OpenSSL::RSA';
+    skip "Crypt::OpenSSL::RSA not installed", 3 unless eval 'require Crypt::OpenSSL::RSA';
 
     my $publickey;
     my $privkey;
@@ -26,9 +26,16 @@ SKIP: {
     $publickey = Crypt::OpenSSL::RSA->new_public_key(slurp("t/rsakey.pub"));
     } or die "unable to read public key";
 
-    # Crypt::OpenSSL::RSA changed its default to sha256 in 0.29_01
-    $privkey->use_sha1_hash;
-    $publickey->use_sha1_hash;
+    # Crypt::OpenSSL::RSA 0.35 through 0.37 disabled PKCS#1 v1.5 padding over
+    # the Marvin attack; 0.38 re-enabled it (PR #103). RFC 5849 3.4.3 requires
+    # it, so RSA-SHA1 simply cannot be done on those releases.
+    skip "Crypt::OpenSSL::RSA $Crypt::OpenSSL::RSA::VERSION cannot do PKCS#1 "
+       . "v1.5 padding, which OAuth RSA-SHA1 requires; upgrade to 0.38+", 3
+        unless eval { Crypt::OpenSSL::RSA->new_private_key(slurp('t/rsakey'))
+                          ->use_pkcs1_padding; 1 };
+
+    # Deliberately left un-tuned: Net::OAuth::SignatureMethod::RSA_SHA1 must
+    # pin the hash and padding itself, since callers in the wild don't.
 
     my $request = Net::OAuth::ProtectedResourceRequest->new(
             consumer_key => 'dpf43f3p2l4k3l03',
@@ -46,6 +53,17 @@ SKIP: {
             },
             signature_key => $privkey,
     );
+
+    # Assert the base string before the signature. It is pure Perl (sorting,
+    # percent-encoding, no crypto), so checking it first splits a failure into
+    # "we built the wrong string" vs "OpenSSL signed it differently" instead of
+    # leaving you to diff two opaque base64 blobs.
+    is($request->signature_base_string,
+        'GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg'
+      . '%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh'
+      . '%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1191242096'
+      . '%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal',
+        'signature base string (RFC 5849 3.4.1)');
 
     $request->sign;
     is($request->signature, "mkZ/wOq5cS7UOyKKdo5Khd4fYpYVhs20K0E8k/DyumO74rjo7s1y+Y+mZ/hBvy2gu6ip/U4XqTRdT0QObAUvrKf+fH/Yfdc6kQsQ9kP3/IgRF1K5Po284UIy8p7DcJGC5udR01aTkNkpqo3XAw+8ljULguhwVC1l+EWHrzKKuZ6li7EOx1It5JxWqCRVn+1+NA8vGlIjcaPb+aIoUmyM2/ytu1041cnvdDGzuiibRgIv770cuXsfkFNtaK5rgjlmhZhDwqULHfWEN9oxcHxY+6EB/HOvwWkYE1CeUoo9Dgm6mn6+DsfkTjfRh4mJRTIyi6jEYaIgY5RaWwSHaXw44A==");


### PR DESCRIPTION
Fixes the FTBFS behind [Debian #1142954](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1142954), which got `libnet-oauth-perl` removed from testing on 2026-07-31 and took Shutter with it. Reported upstream as #8.

## Root cause

`RSA_SHA1.pm` inherited whatever hash and padding the installed `Crypt::OpenSSL::RSA` defaulted to. Those defaults have drifted twice — SHA-256 in 0.29_01, and RSA-PSS in 0.35 (disabled PKCS#1 v1.5 over the Marvin attack; re-enabled by PR #103 in 0.38).

RFC 5849 3.4.3 mandates `RSASSA-PKCS1-v1_5` with SHA-1. So this is **not a stale test fixture** — against Crypt::OpenSSL::RSA 0.35+, Net::OAuth has been emitting RSA-PSS signatures that no compliant OAuth server will accept. `sign()`/`verify()` remained self-consistent, which is why only the fixed vector caught it.

Two observations pinned it down: only the `is()` on line 51 failed while `verify()` on 52 passed, and the signature differed on **every run** — non-determinism that rules out PKCS#1 v1.5 and points at PSS's randomised salt. Confirmed by testing padding modes directly:

```
default (0.41)          33FLZQ6gMKHwPLIaMlpuEuQ6EHwb3WvuHHOi/OL99wEl   <- random each run
use_pkcs1_padding       mkZ/wOq5cS7UOyKKdo5Khd4fYpYVhs20K0E8k/DyumO7   <- matches
use_pkcs1_pss_padding   nbjTT23BKhvSpRfG7liEtc0BkgmyQl8Mt79bHotS7j2J
EXPECTED                mkZ/wOq5cS7UOyKKdo5Khd4fYpYVhs20K0E8k/DyumO7
```

## The fix

`sign()` and `verify()` now pin both the hash and the padding. The `UNIVERSAL::can()` guard preserves the existing duck-typed contract, so any object that `can('sign')` is still accepted.

## Version floor

Probed each release rather than trusting the changelog:

| Crypt::OpenSSL::RSA | `use_pkcs1_padding` | `t/02-rsa.t` |
|---|---|---|
| <= 0.34 | OK | passes |
| **0.35 - 0.37** | **croaks (Marvin attack)** | **skips, with reason** |
| 0.38 - 0.41 | OK | passes |
| absent | - | skips (unchanged) |

RSA-SHA1 is genuinely impossible on 0.35-0.37. The test **skips** there rather than dying, since dying would reintroduce the exact FTBFS this PR fixes; the library still refuses loudly at runtime:

```
Your Crypt::OpenSSL::RSA cannot do use_pkcs1_padding, which OAuth RSA-SHA1
requires (RFC 5849 3.4.3): PKCS#1 1.5 is disabled ... at ...RSA_SHA1.pm line 13
```

Build succeeds; anyone actually signing gets a clear failure instead of a bad signature.

`Crypt::OpenSSL::RSA >= 0.38` is declared as a **recommends** (runtime and test), not a hard prereq — RSA-SHA1 is optional, and forcing an XS + OpenSSL-headers build on every installer is a real burden. Declaring `prereqs` required moving `META_MERGE` to meta-spec 2, so `resources` was converted to 2.0 form; both `META.json` (spec 2) and the auto-downgraded `META.yml` (1.4) were verified.

## Test changes

- Asserts the **signature base string** separately from the signature. It is pure Perl — sorting and percent-encoding, no crypto — so a failure now distinguishes "we built the wrong string" from "OpenSSL signed it differently" instead of leaving you to diff two opaque base64 blobs.
- Removes the manual `use_sha1_hash` calls. Callers in the wild do not make them, so they were masking the real code path; the module must pin its own defaults. Verified a caller that never touches `use_sha1_hash` now gets the correct RFC 5849 signature.

## Verification

Full suite, 113 tests, `Result: PASS` against Crypt::OpenSSL::RSA 0.31, 0.34, 0.37, 0.38, 0.41, and with the module absent.

## Not addressed

The autopkgtest failures on i386, loong64 and s390x (amd64, arm64, armhf, ppc64el, riscv64 all pass) are a separate signal, and are not the blocking issue in the migration excuses — that is #1142954 alone. They carry the retriable marker, the failing set does not map to a clean portability class (armhf is 32-bit and passes; only s390x is big-endian), and ci.debian.net logs are unreachable (403/404). I make no claim this PR affects them.