### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,95 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  perl:
+    name: perl ${{ matrix.perl }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl: ['5.16', '5.20', '5.24', '5.28', '5.32', '5.36', '5.38', 'latest']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up perl ${{ matrix.perl }}
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      - run: perl -V
+
+      - name: Install dependencies
+        run: cpanm --notest --installdeps .
+
+      # Only RSA-SHA1 needs this, and it is a recommends rather than a hard
+      # prereq, so a build failure here must not fail the job -- t/02-rsa.t
+      # skips cleanly when it is missing.
+      - name: Install Crypt::OpenSSL::RSA (optional)
+        run: |
+          cpanm --notest Crypt::OpenSSL::RSA \
+            || echo "::warning::Crypt::OpenSSL::RSA unavailable on perl ${{ matrix.perl }}; RSA-SHA1 tests will skip"
+
+      - name: Build
+        run: |
+          perl Makefile.PL
+          make
+
+      - name: Test
+        run: make test
+
+  # Net-OAuth was removed from Debian testing because Crypt::OpenSSL::RSA
+  # changed its default padding underneath us (Debian #1142954). Nothing in a
+  # single-version matrix catches that class of drift, so pin the versions that
+  # bracket the behaviour change and assert all of them stay green.
+  crypt-openssl-rsa:
+    name: Crypt::OpenSSL::RSA ${{ matrix.rsa }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rsa:
+          - '0.34'    # last release before PKCS#1 v1.5 was disabled
+          - '0.37'    # v1.5 disabled: RSA-SHA1 impossible, tests must skip
+          - '0.38'    # v1.5 re-enabled (PR #103)
+          - 'latest'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: 'latest'
+
+      - name: Install dependencies
+        run: cpanm --notest --installdeps .
+
+      - name: Install Crypt::OpenSSL::RSA ${{ matrix.rsa }}
+        run: |
+          if [ "${{ matrix.rsa }}" = "latest" ]; then
+            cpanm --notest Crypt::OpenSSL::RSA
+          else
+            cpanm --notest "Crypt::OpenSSL::RSA@${{ matrix.rsa }}"
+          fi
+          perl -MCrypt::OpenSSL::RSA \
+            -e 'print "Crypt::OpenSSL::RSA $Crypt::OpenSSL::RSA::VERSION\n"'
+
+      - name: Build
+        run: |
+          perl Makefile.PL
+          make
+
+      - name: Test
+        run: make test
+
+      # A skip is the correct outcome on 0.35-0.37 but an invisible one, so
+      # make the log state which path was taken.
+      - name: Show RSA-SHA1 test detail
+        run: prove -lv t/02-rsa.t

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,11 @@ jobs:
         rsa:
           - '0.34'    # last release before PKCS#1 v1.5 was disabled
           - '0.37'    # v1.5 disabled: RSA-SHA1 impossible, tests must skip
-          - '0.38'    # v1.5 re-enabled (PR #103)
+          # 0.38 re-enabled v1.5 (PR #103) and would be the natural boundary
+          # to pin, but it was superseded by 0.39 the same day, deleted from
+          # CPAN, and its Makefile.PL does not configure. 0.39 is the first
+          # installable release with v1.5 back.
+          - '0.39'
           - 'latest'
 
     steps:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,24 +27,22 @@ WriteMakefile(
     'EXE_FILES'   => [],
     'PL_FILES'    => {},
     'META_MERGE'  => {
-        'meta-spec' => { version => 2 },
-        prereqs     => {
-            # Only needed for the RSA-SHA1 signature method, so not a hard
-            # prereq. 0.38 is a floor rather than a preference: 0.35 through
-            # 0.37 disabled the PKCS#1 v1.5 padding that RFC 5849 3.4.3
-            # mandates, and 0.38 re-enabled it.
-            runtime => { recommends => { 'Crypt::OpenSSL::RSA' => '0.38' } },
-            test    => { recommends => { 'Crypt::OpenSSL::RSA' => '0.38' } },
-        },
+        # Deliberately meta-spec 1.4 shaped. A spec 2 "prereqs" key here does
+        # not merge on ExtUtils::MakeMaker older than 7.x -- it replaces the
+        # generated prereqs wholesale, silently dropping every runtime and
+        # test requirement from META. Perl 5.16 ships 6.63_02, so that is a
+        # live configuration. A top level "recommends" sits beside "requires"
+        # instead of overwriting it, and newer toolchains still convert it to
+        # prereqs.runtime.recommends in the spec 2 output.
+        #
+        # Only RSA-SHA1 needs this, hence a recommends rather than a hard
+        # prereq. 0.38 is a floor rather than a preference: 0.35 through 0.37
+        # disabled the PKCS#1 v1.5 padding that RFC 5849 3.4.3 mandates, and
+        # 0.38 re-enabled it.
+        recommends => { 'Crypt::OpenSSL::RSA' => '0.38' },
         resources => {
-            bugtracker => {
-                web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Net-OAuth',
-            },
-            repository => {
-                url  => 'https://github.com/keeth/Net-OAuth.git',
-                web  => 'https://github.com/keeth/Net-OAuth',
-                type => 'git',
-            },
+            bugtracker => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Net-OAuth',
+            repository => 'https://github.com/keeth/Net-OAuth.git',
         },
     },
 );


### PR DESCRIPTION
Stacked on #9 — **base is `fix/rsa-sha1-pkcs1-padding`, not `master`**, so the diff stays clean and the run is green. Retarget to `master` once #9 merges. (Branching this off `master` would have gone red immediately on `t/02-rsa.t`, since CI installs a current Crypt::OpenSSL::RSA and master still has the padding bug.)

The repo has no CI today, which is the direct reason this class of bug reached Debian before it reached us.

## Job 1 — `perl`

perl **5.16 → latest** on `ubuntu-latest`, 8 jobs, `fail-fast: false`.

The 5.16 floor is deliberate: stable distributions are where these reports come from, and a modern-only matrix would not exercise the population that filed #1142954.

## Job 2 — `crypt-openssl-rsa`

This is the job that answers "would a test have caught the Debian failure?"

The honest answer is that `t/02-rsa.t` **already caught it** — Debian's FTBFS *was* that test failing. Coverage was never the gap. What was missing is anything running it against a current dependency. So this job pins the versions bracketing the padding change:

| Pin | Why |
|---|---|
| `0.34` | last release before PKCS#1 v1.5 was disabled |
| `0.37` | v1.5 disabled — RSA-SHA1 impossible, tests **must skip** |
| `0.38` | v1.5 re-enabled (PR #103) |
| `latest` | catches the next default change |

Including 0.37 asserts the *skip* path stays working, not just the pass path — otherwise a future change could turn that clean skip back into the FTBFS #9 fixes, and nothing would notice. The job ends with `prove -lv t/02-rsa.t` so the log states which path was taken; a skip is the correct outcome there but an invisible one.

## Notes

- `Crypt::OpenSSL::RSA` installs **best-effort** (`|| echo "::warning::..."`). It is a recommends rather than a hard prereq, so a build failure on an older perl should warn and let `t/02-rsa.t` skip, not fail the job. This also exercises the recommends declaration added in #9.
- The 5.16 floor is a first cut. If the older rows fail for reasons unrelated to this dist — a dependency dropping old-perl support, most likely — the floor should move up rather than the matrix be papered over. Worth watching the first run.
- No `MIN_PERL_VERSION` is declared in the dist yet; that belongs to the metadata PR, so CI here tests 5.16 without the dist asserting it.